### PR TITLE
feat: create GitHub issue on pipeline failure

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  issues: write
 
 concurrency:
   group: ci-main
@@ -145,3 +146,27 @@ jobs:
           body_path: release_notes.md
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  notify-failure:
+    if: ${{ failure() }}
+    needs: [ci-release]
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Create issue on pipeline failure
+        run: |
+          gh issue create \
+            --repo "${{ github.repository }}" \
+            --title "Pipeline failure: ${{ github.workflow }} (#${{ github.run_number }})" \
+            --label "ci" \
+            --body "$(cat <<EOF
+          **Workflow:** \`${{ github.workflow }}\`
+          **Run:** ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          **Branch:** \`${{ github.ref_name }}\`
+          **Commit:** \`${{ github.sha }}\`
+          **Triggered by:** ${{ github.actor }}
+          EOF
+          )"
+        env:
+          GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Summary

- Adds `issues: write` permission to the CI workflow
- Adds a `notify-failure` job that creates a GitHub issue with run details when the `ci-release` job fails
- Issue includes workflow name, run link, branch, commit, and triggering actor

## Test plan

- [ ] Verify workflow YAML is valid
- [ ] Trigger a workflow run and confirm the notify-failure job runs on failure
- [ ] Confirm the created issue contains correct metadata