### PR TITLE
docs: use main branch for screenshot link

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Go Reference](https://pkg.go.dev/badge/github.com/catgoose/crooner.svg)](https://pkg.go.dev/github.com/catgoose/crooner)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-![image](https://github.com/catgoose/screenshots/blob/fb17ed7cd8e989691447b0e7a755d93a677abbfd/crooner/crooner.png)
+![image](https://github.com/catgoose/screenshots/blob/main/crooner/crooner.png)
 
 <!--toc:start-->
 


### PR DESCRIPTION
## Summary

- Replace pinned commit hash in screenshot URL with `main` branch reference so the image stays current automatically