### PR TITLE
feat: derive safe session cookie name from app name

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,7 @@ func main() {
   ```
 
 - `NewSCSManager` applies secure defaults. Only reach for advanced config when you have special requirements.
+- If you need a readable app-derived cookie name instead of a non-guessable one, use `crooner.DeriveSessionCookieName(appName)` with `crooner.WithCookieName(...)`.
 
 ### Content Security Policy (CSP) and Security Headers
 
@@ -311,6 +312,8 @@ Crooner uses idiomatic Go functional options for session config.
 | `WithLifetime(lifetime time.Duration)`             | Sets the session lifetime.                                                                                |
 | `WithStore(store scs.Store)`                       | Sets a custom session store backend (e.g., Redis).                                                        |
 
+`DeriveSessionCookieName(appName string)` returns a deterministic, valid cookie token name in the readable `crooner-<app>` convention. Crooner owns the `crooner-` prefix convention; app code still decides whether to use this readable name, a custom name, or the non-guessable `WithPersistentCookieName` convention.
+
 #### Example Usage
 
 ```go
@@ -336,7 +339,7 @@ handler := crooner.RequireAuth(sessionMgr, routes)(mux)
 
 ```go
 cfg := crooner.DefaultSecureSessionConfig()
-cfg.CookieName = "crooner-" + myCustomSuffix
+cfg.CookieName = crooner.DeriveSessionCookieName(appConfig.AppName)
 cfg.Lifetime = 7 * 24 * time.Hour
 cfg.CookieDomain = ".example.com"
 cfg.CookieSameSite = http.SameSiteStrictMode

--- a/session.go
+++ b/session.go
@@ -15,9 +15,15 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	scs "github.com/alexedwards/scs/v2"
+)
+
+const (
+	sessionCookieNamePrefix   = "crooner-"
+	defaultSessionCookieLabel = "session"
 )
 
 // SessionManager abstracts session operations for pluggable backends (SCS, etc.)
@@ -218,7 +224,7 @@ type SessionConfig struct {
 // DefaultSecureSessionConfig returns a config with secure defaults.
 func DefaultSecureSessionConfig() SessionConfig {
 	return SessionConfig{
-		CookieName:     "crooner-" + randomSuffix(),
+		CookieName:     sessionCookieNamePrefix + randomSuffix(),
 		CookieSecure:   true,
 		CookieHTTPOnly: true,
 		CookieSameSite: http.SameSiteLaxMode,
@@ -293,7 +299,7 @@ func WithStore(store scs.Store) SessionOption {
 func WithPersistentCookieName(secret, appName string) SessionOption {
 	return func(cfg *SessionConfig) {
 		suffix := PersistentCookieSuffix(secret, appName)
-		cfg.CookieName = "crooner-" + suffix
+		cfg.CookieName = sessionCookieNamePrefix + suffix
 	}
 }
 
@@ -338,6 +344,49 @@ func PersistentCookieSuffix(secret, appName string) string {
 	h.Write([]byte(secret))
 	h.Write([]byte(appName))
 	return hex.EncodeToString(h.Sum(nil))[:16] // Use first 16 hex chars for brevity
+}
+
+// DeriveSessionCookieName returns a deterministic, valid cookie name from an app name.
+//
+// The returned name uses Crooner's readable cookie-name convention:
+// "crooner-" plus a sanitized app label. Use WithPersistentCookieName when you
+// need a non-guessable cookie name derived from a secret.
+func DeriveSessionCookieName(appName string) string {
+	appName = strings.TrimSpace(appName)
+	var b strings.Builder
+	lastWasSeparator := false
+
+	for i := 0; i < len(appName); i++ {
+		c := appName[i]
+		if isCookieNameLabelChar(c) {
+			b.WriteByte(toLowerASCII(c))
+			lastWasSeparator = false
+			continue
+		}
+		if b.Len() > 0 && !lastWasSeparator {
+			b.WriteByte('-')
+			lastWasSeparator = true
+		}
+	}
+
+	label := strings.Trim(b.String(), "-")
+	if label == "" {
+		label = defaultSessionCookieLabel
+	}
+	return sessionCookieNamePrefix + label
+}
+
+func isCookieNameLabelChar(c byte) bool {
+	return (c >= 'a' && c <= 'z') ||
+		(c >= 'A' && c <= 'Z') ||
+		(c >= '0' && c <= '9')
+}
+
+func toLowerASCII(c byte) byte {
+	if c >= 'A' && c <= 'Z' {
+		return c + ('a' - 'A')
+	}
+	return c
 }
 
 // randomSuffix returns a random 16-character hex string for cookie names.

--- a/session_test.go
+++ b/session_test.go
@@ -149,6 +149,78 @@ func TestPersistentCookieSuffix_DifferentInputs_DifferentOutputs(t *testing.T) {
 	}
 }
 
+func TestDeriveSessionCookieName(t *testing.T) {
+	tests := []struct {
+		name    string
+		appName string
+		want    string
+	}{
+		{
+			name:    "simple",
+			appName: "Annex",
+			want:    "crooner-annex",
+		},
+		{
+			name:    "spaces and punctuation",
+			appName: "Annex Admin: Prod!",
+			want:    "crooner-annex-admin-prod",
+		},
+		{
+			name:    "collapses separators",
+			appName: "  My---App...API  ",
+			want:    "crooner-my-app-api",
+		},
+		{
+			name:    "non ascii falls back to separators",
+			appName: "Café Portal",
+			want:    "crooner-caf-portal",
+		},
+		{
+			name:    "empty falls back",
+			appName: "",
+			want:    "crooner-session",
+		},
+		{
+			name:    "only punctuation falls back",
+			appName: " !@#$ ",
+			want:    "crooner-session",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := DeriveSessionCookieName(tt.appName)
+			if got != tt.want {
+				t.Fatalf("DeriveSessionCookieName(%q) = %q, want %q", tt.appName, got, tt.want)
+			}
+			if !isValidCookieTokenName(got) {
+				t.Fatalf("DeriveSessionCookieName(%q) = %q, not a valid cookie token name", tt.appName, got)
+			}
+		})
+	}
+}
+
+func isValidCookieTokenName(name string) bool {
+	if name == "" {
+		return false
+	}
+	for i := 0; i < len(name); i++ {
+		c := name[i]
+		if (c >= 'a' && c <= 'z') ||
+			(c >= 'A' && c <= 'Z') ||
+			(c >= '0' && c <= '9') {
+			continue
+		}
+		switch c {
+		case '!', '#', '$', '%', '&', '\'', '*', '+', '-', '.', '^', '_', '`', '|', '~':
+			continue
+		default:
+			return false
+		}
+	}
+	return true
+}
+
 func TestGetString_Found(t *testing.T) {
 	sm := newMapSessionManager()
 	r := testRequest()


### PR DESCRIPTION
## Summary
- add `DeriveSessionCookieName(appName string)` for deterministic readable session cookie names
- keep `WithPersistentCookieName` output compatible while centralizing the `crooner-` prefix
- document readable derived names versus non-guessable persistent names

Closes #29

## Validation
- `git diff --check`
- `go test -count=1 ./...`
- `go vet ./...`